### PR TITLE
Update impute.R

### DIFF
--- a/R/impute.R
+++ b/R/impute.R
@@ -67,17 +67,12 @@ imputeChr <- function(Gna, infos.imp, ind.chr, alpha, size, p.train, n.cor, seed
           ind.col <- ind.chr[which(corr[, i] != 0)]
           if (length(ind.col) < 5L)
             ind.col <- intersect(setdiff(-size:size + snp, snp), ind.chr)
-          
-          if (sum(X.label[ind.train]) == 0) 
-            base_score <- 0.0000001
-          else
-            base_score <- mean(X.label[ind.train]) / 2
-          
+                    
           bst <- xgboost(
             data = X2[ind.train, ind.col, drop = FALSE],
             label = X.label[ind.train],
             objective = "binary:logistic",
-            base_score = base_score,
+            base_score = min(max(1e-7, mean(X.label[ind.train])), 1 - 1e-7),
             nrounds = 10,
             params = list(max_depth = 4),
             nthread = 1,


### PR DESCRIPTION
When "X.label[ind.train]" as all values with zero base_score is going to be zero. xgboost doesn't accept base_score equal to zero.