### PR TITLE
Add plink.options to snp_beagleImpute function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Encoding: UTF-8
 Package: bigsnpr
 Type: Package
 Title: Analysis of Massive SNP Arrays
-Version: 0.11.4
-Date: 2019-06-21
+Version: 0.11.5
+Date: 2019-07-02
 Authors@R: c(
     person("Florian", "Privé", 
            email = "florian.prive.21@gmail.com", 

--- a/R/external-software.R
+++ b/R/external-software.R
@@ -435,6 +435,8 @@ snp_plinkIBDQC <- function(plink.path,
 #'   value for this parameter is `ncores = parallel::detectCores() - 1`.
 #' @param extra.options Other options to be passed to Beagle as a string. More
 #'   options can be found at Beagle's website.
+#' @param plink.options Other options to be passed to PLINK as a string. More
+#'   options can be found at \url{https://www.cog-genomics.org/plink2/filter}.
 #'
 #' @references B L Browning and S R Browning (2016).
 #' Genotype imputation with millions of reference samples.
@@ -451,7 +453,8 @@ snp_beagleImpute <- function(beagle.path,
                              bedfile.out = NULL,
                              memory.max = 3,
                              ncores = 1,
-                             extra.options = "") {
+                             extra.options = "",
+                             plink.options = "") {
 
   # get input and output right
   prefix.in <- sub("\\.bed$", "", bedfile.in)
@@ -470,7 +473,8 @@ snp_beagleImpute <- function(beagle.path,
       "--bfile", prefix.in,
       "--recode vcf bgz", # .vcf.gz extension
       "--out", tmpfile1,
-      "--threads", ncores
+      "--threads", ncores,
+      plink.options
     )
   )
   vcf1 <- paste0(tmpfile1, ".vcf.gz")
@@ -495,7 +499,8 @@ snp_beagleImpute <- function(beagle.path,
     paste(
       plink.path,
       "--vcf", vcf2,
-      "--out", prefix.out
+      "--out", prefix.out,
+      plink.options
     )
   )
 

--- a/man/snp_beagleImpute.Rd
+++ b/man/snp_beagleImpute.Rd
@@ -5,7 +5,8 @@
 \title{Imputation}
 \usage{
 snp_beagleImpute(beagle.path, plink.path, bedfile.in, bedfile.out = NULL,
-  memory.max = 3, ncores = 1, extra.options = "")
+  memory.max = 3, ncores = 1, extra.options = "",
+  plink.options = "")
 }
 \arguments{
 \item{beagle.path}{Path to the executable of Beagle v4+.}
@@ -25,6 +26,9 @@ value for this parameter is \code{ncores = parallel::detectCores() - 1}.}
 
 \item{extra.options}{Other options to be passed to Beagle as a string. More
 options can be found at Beagle's website.}
+
+\item{plink.options}{Other options to be passed to PLINK as a string. More
+options can be found at \url{https://www.cog-genomics.org/plink2/filter}.}
 }
 \value{
 The path of the new bedfile.


### PR DESCRIPTION
These changes allow the user to add extra.options to both the external Beagle software and the external PLINK software.