### PR TITLE
fix matching proportion check

### DIFF
--- a/R/match-alleles.R
+++ b/R/match-alleles.R
@@ -88,7 +88,7 @@ snp_match <- function(sumstats, info_snp,
            format(sum(matched$`_FLIP_`), big.mark = ","),
            format(sum(matched$`_REV_`),  big.mark = ","))
 
-  if (nrow(matched) < (match.min.prop * min(ncol(sumstats), ncol(info_snp))))
+  if (nrow(matched) < (match.min.prop * min(nrow(sumstats), nrow(info_snp))))
     stop2("Not enough variants have been matched.")
 
   as.data.frame(matched[, c("_FLIP_", "_REV_") := NULL][order(chr, pos)])


### PR DESCRIPTION
`match.min.prop` in `snp_match()` needs to be evaluated by checking the number of rows (i.e. number of variants in each input dataset).

Here's an example [from the ldpred2 tutorial](https://privefl.github.io/bigsnpr/articles/LDpred2.html#matching-variants-between-genotype-data-and-summary-statistics) which should demonstrate that the variants are in the rows, as opposed to the columns which contain the information (genomic position, GWAS results etc)

```
sumstats$n_eff <- 4 / (1 / sumstats$n_case + 1 / sumstats$n_control)
sumstats$n_case <- sumstats$n_control <- NULL
names(sumstats) <- c("chr", "rsid", "pos", "a0", "a1", "beta", "beta_se", "p", "n_eff")
map <- obj.bigSNP$map[-(2:3)]
names(map) <- c("chr", "pos", "a0", "a1")
info_snp <- snp_match(sumstats, map)
```

Thanks for your work on these packages and best of luck with the paper!