### PR TITLE
update test for dplyr 1.0.8

### DIFF
--- a/tests/testthat/test-1-readBGEN.R
+++ b/tests/testthat/test-1-readBGEN.R
@@ -64,8 +64,8 @@ test_that("same variant infos as with QCTOOL", {
   test <- snp_attach(snp_readBGEN(bgen_file, tempfile(), list(IDs), ncores = ncores()))
 
   expect_identical(
-    dplyr::relocate(dplyr::mutate(test$map[-19, 1:6], chromosome = as.integer(chromosome)), rsid, .before = "chromosome"),
-    dplyr::as_tibble(dplyr::transmute(
+    dplyr::mutate(test$map[-19, 1:6], chromosome = as.integer(chromosome)),
+    dplyr::as_tibble(dplyr::select(
       snp_info[-19, ], chromosome, marker.ID = alternate_ids, rsid,
       physical.pos = position, allele1 = alleleA, allele2 = alleleB))
   )

--- a/tests/testthat/test-1-readBGEN.R
+++ b/tests/testthat/test-1-readBGEN.R
@@ -64,7 +64,7 @@ test_that("same variant infos as with QCTOOL", {
   test <- snp_attach(snp_readBGEN(bgen_file, tempfile(), list(IDs), ncores = ncores()))
 
   expect_identical(
-    dplyr::mutate(test$map[-19, 1:6], chromosome = as.integer(chromosome)),
+    dplyr::relocate(dplyr::mutate(test$map[-19, 1:6], chromosome = as.integer(chromosome)), rsid, .before = "chromosome"),
     dplyr::as_tibble(dplyr::transmute(
       snp_info[-19, ], chromosome, marker.ID = alternate_ids, rsid,
       physical.pos = position, allele1 = alleleA, allele2 = alleleB))


### PR DESCRIPTION
We're about to release dplyr 1.0.8 (https://github.com/tidyverse/dplyr/issues/6080) which would cause this failure in one test: 

```
> checking installed package size ... NOTE
    installed size is 18.3Mb
    sub-directories of 1Mb or more:
      libs  16.5Mb

── Test failures ────────────────────────────────────────────────────────────────────────────── testthat ────

> library(testthat)
> library(bigsnpr)
Loading required package: bigstatsr
> 
> for (k in 1:9)
+   test_check("bigsnpr", filter = paste0(k, '-'))
══ Skipped tests ═══════════════════════════════════════════════════════════════
• is_cran is TRUE (1)

══ Failed tests ════════════════════════════════════════════════════════════════
── Failure (test-1-readBGEN.R:66:3): same variant infos as with QCTOOL ─────────
dplyr::mutate(test$map[-19, 1:6], chromosome = as.integer(chromosome)) not identical to dplyr::as_tibble(...).
Names: 3 string mismatches
Component 1: Modes: numeric, character
Component 1: target is numeric, current is character
Component 2: Modes: character, numeric
Component 2: target is character, current is numeric
Component 3: 198 string mismatches

[ FAIL 1 | WARN 0 | SKIP 1 | PASS 226 ]
Error: Test failures
Execution halted
```

This is because of this fix: https://github.com/tidyverse/dplyr/pull/6035